### PR TITLE
Fixed Inappropriate Logical Expression

### DIFF
--- a/faker/faker.go
+++ b/faker/faker.go
@@ -395,7 +395,7 @@ func GetValue(t reflect.Type, level int) (reflect.Value, error) {
 		v := reflect.New(t.Elem())
 		var val reflect.Value
 		var err error
-		if a != reflect.Zero(t).Interface() {
+		if a.Interface() != reflect.Zero(t).Interface() {
 			val, err = GetValue(t.Elem(), level+1)
 			if err != nil {
 				return reflect.Value{}, fmt.Errorf("[GetValue] has GetValue on t.Elem() err: %v", err)


### PR DESCRIPTION
## Summary
This PR fixes a logical bug in your codebase.


## Description
While triaging your project, our bug fixing tool generated the following message(s)-
> In file: [faker.go](https://github.com/bytedance/nxt_unit/blob/main/faker/faker.go#L398), a logical equality check operation is performed between two [`reflect.Value`](https://pkg.go.dev/reflect#Value) instances that represent run-time data. This is incorrect because it compares the `reflect` package's internal representations, which is typically not intended. Instead, the intent is most likely to compare the underlying values. iCR suggested that such comparison should be done with [`value.Interface()`](https://pkg.go.dev/reflect#Value.Interface).


## Changes
I have changed the comparison by using `a.Interface()` on the left side.


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
