### PR TITLE
BUGFIX: Fixed Regex for `getPackRelativePath` method

### DIFF
--- a/manager/reporter/analyser.go
+++ b/manager/reporter/analyser.go
@@ -130,7 +130,7 @@ func (p *panicErr) Analysis(ctx context.Context, contents, filePath, mirrorFileN
 	return
 }
 func getPackRelativePath(filePath string) string {
-	reg, err := regexp.Compile(`github.com/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*)`)
+	reg, err := regexp.Compile(`github\.com/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*)`)
 	if err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
## Description
While triaging your project, our bug fixing tool generated the following message-

> In file: [analyser.go](https://github.com/bytedance/nxt_unit/blob/main/manager/reporter/analyser.go#L133), there's a regular expression that has a dot before "com". When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. 

After manually triaging and testing, we found a solution that only accepts URLs as expected.

## Proof of Concept
For example, running the code below gives the output:
```go
package main

import (
	"fmt"
	"regexp"
)

func main() {

	case1 := "github$com/foo/bar/tree/baz"
	case2 := "github.com/foo/bar/tree/main"

	regex, _ := regexp.Compile(`github.com/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*)`)
	fmt.Println("Using Regex:", regex)
	result := regex.FindAllStringSubmatch(case1, 1)
	fmt.Println(result)
	result = regex.FindAllStringSubmatch(case2, 1)
	fmt.Println(result)

	fmt.Println()
	regex, _ = regexp.Compile(`github\.com/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*)`)
	fmt.Println("Using Regex:", regex)
	result = regex.FindAllStringSubmatch(case1, 1)
	fmt.Println(result)
	result = regex.FindAllStringSubmatch(case2, 1)
	fmt.Println(result)

}
```
```shell
Using Regex: github.com/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*)
[[github$com/foo/bar/tree/baz foo bar tree/baz]]
[[github.com/foo/bar/tree/main foo bar tree/main]]

Using Regex: github\.com/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*)
[]
[[github.com/foo/bar/tree/main foo bar tree/main]]
```
As you can see, the corrected version of the regex works correctly.


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running CodeQL and then manually triaging the results.